### PR TITLE
#bugfix/remove-duplicated-iosgaensdkconfig

### DIFF
--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/model/ConfigResponse.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/model/ConfigResponse.java
@@ -30,15 +30,6 @@ public class ConfigResponse {
 		return this.forceTraceShutdown;
 	}
 
-
-	public GAENSDKConfig getIOSGaenSdkConfig() {
-		return this.iOSGaenSdkConfig;
-	}
-
-	public void setIOSGaenSdkConfig(GAENSDKConfig iOSGaenSdkConfig) {
-		this.iOSGaenSdkConfig = iOSGaenSdkConfig;
-	}
-
 	public boolean isForceUpdate() {
 		return forceUpdate;
 	}


### PR DESCRIPTION
- Removed duplicated getters/setters for the iOSGaenSdkConfig property on ConfigResponse.